### PR TITLE
チームリーダーが、他のチームメンバーにリーダー権限譲渡機能

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_team, only: %i[show edit update destroy]
+  before_action :set_team, only: %i[show edit update destroy update_owner]
 
   def index
     @teams = Team.all
@@ -38,6 +38,14 @@ class TeamsController < ApplicationController
     end
   end
 
+  def update_owner
+    @team.owner = User.find(params[:assign_user_id])
+    if @team.update(team_params)
+      redirect_to @team, notice: 'リーダー変更に成功しました！'
+      TeamMailer.team_mail(@team.owner).deliver
+    end
+  end
+
   def destroy
     @team.destroy
     redirect_to teams_url, notice: 'チーム削除に成功しました！'
@@ -54,6 +62,6 @@ class TeamsController < ApplicationController
   end
 
   def team_params
-    params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id]
+    params.fetch(:team, {}).permit %i[name icon icon_cache owner_id keep_team_id assign_user_id]
   end
 end

--- a/app/mailers/team_mailer.rb
+++ b/app/mailers/team_mailer.rb
@@ -1,0 +1,7 @@
+class TeamMailer < ApplicationMailer
+  def team_mail(owner)
+    @owner = owner
+
+    mail to: "#{@owner.email}", subject: "確認メール"
+  end
+end

--- a/app/views/team_mailer/team_mail.html.erb
+++ b/app/views/team_mailer/team_mail.html.erb
@@ -1,0 +1,3 @@
+<h1>あなたが、DIVEINTOPOSTのチームリーダーになりました！</h1>
+
+<h4>email: <%= @owner.email %></h4>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -42,6 +42,9 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td><%= link_to '削除', team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if current_user == @team.owner %>
+                        <td><%= link_to '権限移動', update_owner_team_path(@team, assign_user_id: assign.user_id), method: :put, class: 'btn btn-sm btn-info' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,13 +8,16 @@ Rails.application.routes.draw do
     passwords: 'users/passwords'
   }
   resource :user
-  
+
   resources :teams do
     resources :assigns, only: %w(create destroy)
     resources :agendas, shallow: true do
       resources :articles do
         resources :comments
       end
+    end
+    member do
+      put :update_owner
     end
   end
 

--- a/spec/mailers/previews/team_mailer_preview.rb
+++ b/spec/mailers/previews/team_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/team_mailer
+class TeamMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/team_mailer_spec.rb
+++ b/spec/mailers/team_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe TeamMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
以下の要件で作成されることを想定している

そのTeamのリーダー（オーナー）が、Teamのshowページを開くと、各チームメンバーの「削除」ボタンの右隣に「権限移動」のボタンが出現する
そのボタンを押すと、そのTeamのオーナーが選択したUserに変更される
アクションはTeamコントローラに任意のものを追加する
Teamのオーナーが変更されたら、新しくオーナーになったユーザーに通知メールが飛ぶ
情報処理が完了した後はそのTeamのshowに飛ぶ（つまり同じ場所にredirectする）
その他、アプリケーションの挙動に不審な点やエラーがないこと
2018-12-02 20 37 18

その他、質問や確認事項などがあれば別途課題投稿欄のコメントで質問すること

今回テストは不要